### PR TITLE
chore: Updated actions/download-artifact version to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   using: 'composite'
   steps:
     - name: '📥 download artifact'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
### Description of the Change

Updated the version of actions/download-artifact to v4 to make it possible to work with artifacts during the build process

### Screenshot or Gif

N/A

### Applicable Issues

N/A